### PR TITLE
Introduce credentials provider (#3224)

### DIFF
--- a/src/main/java/redis/clients/jedis/CommandArguments.java
+++ b/src/main/java/redis/clients/jedis/CommandArguments.java
@@ -28,7 +28,9 @@ public class CommandArguments implements Iterable<Rawable> {
   }
 
   public CommandArguments add(Object arg) {
-    if (arg instanceof Rawable) {
+    if (arg == null) {
+      throw new IllegalArgumentException("null is not a valid argument.");
+    } else if (arg instanceof Rawable) {
       args.add((Rawable) arg);
     } else if (arg instanceof byte[]) {
       args.add(RawableFactory.from((byte[]) arg));
@@ -37,9 +39,6 @@ public class CommandArguments implements Iterable<Rawable> {
     } else if (arg instanceof Boolean) {
       args.add(RawableFactory.from(Integer.toString((Boolean) arg ? 1 : 0)));
     } else {
-      if (arg == null) {
-        throw new IllegalArgumentException("null is not a valid argument.");
-      }
       args.add(RawableFactory.from(String.valueOf(arg)));
     }
     return this;

--- a/src/main/java/redis/clients/jedis/ConnectionFactory.java
+++ b/src/main/java/redis/clients/jedis/ConnectionFactory.java
@@ -35,6 +35,11 @@ public class ConnectionFactory implements PooledObjectFactory<Connection> {
     this.jedisSocketFactory = jedisSocketFactory;
   }
 
+  /**
+   * @deprecated Use {@link RedisCredentialsProvider} through
+   * {@link JedisClientConfig#getCredentialsProvider()}.
+   */
+  @Deprecated
   public void setPassword(final String password) {
     this.clientConfig.updatePassword(password);
   }

--- a/src/main/java/redis/clients/jedis/DefaultRedisCredentials.java
+++ b/src/main/java/redis/clients/jedis/DefaultRedisCredentials.java
@@ -1,0 +1,38 @@
+package redis.clients.jedis;
+
+public final class DefaultRedisCredentials implements RedisCredentials {
+
+  private final String user;
+  private final char[] password;
+
+  public DefaultRedisCredentials(String user, char[] password) {
+    this.user = user;
+    this.password = password;
+  }
+
+  public DefaultRedisCredentials(String user, CharSequence password) {
+    this.user = user;
+    this.password = password == null ? null
+        : password instanceof String ? ((String) password).toCharArray()
+            : toCharArray(password);
+  }
+
+  @Override
+  public String getUser() {
+    return user;
+  }
+
+  @Override
+  public char[] getPassword() {
+    return password;
+  }
+
+  private static char[] toCharArray(CharSequence seq) {
+    final int len = seq.length();
+    char[] arr = new char[len];
+    for (int i = 0; i < len; i++) {
+      arr[i] = seq.charAt(i);
+    }
+    return arr;
+  }
+}

--- a/src/main/java/redis/clients/jedis/DefaultRedisCredentialsProvider.java
+++ b/src/main/java/redis/clients/jedis/DefaultRedisCredentialsProvider.java
@@ -1,0 +1,19 @@
+package redis.clients.jedis;
+
+public final class DefaultRedisCredentialsProvider implements RedisCredentialsProvider {
+
+  private volatile RedisCredentials credentials;
+
+  public DefaultRedisCredentialsProvider(RedisCredentials credentials) {
+    this.credentials = credentials;
+  }
+
+  public void setCredentials(RedisCredentials credentials) {
+    this.credentials = credentials;
+  }
+
+  @Override
+  public RedisCredentials get() {
+    return this.credentials;
+  }
+}

--- a/src/main/java/redis/clients/jedis/JedisClientConfig.java
+++ b/src/main/java/redis/clients/jedis/JedisClientConfig.java
@@ -1,5 +1,6 @@
 package redis.clients.jedis;
 
+import java.util.function.Supplier;
 import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.SSLParameters;
 import javax.net.ssl.SSLSocketFactory;
@@ -39,7 +40,13 @@ public interface JedisClientConfig {
     return null;
   }
 
+  @Deprecated
   default void updatePassword(String password) {
+  }
+
+  default Supplier<RedisCredentials> getCredentialsProvider() {
+    return new DefaultRedisCredentialsProvider(
+        new DefaultRedisCredentials(getUser(), getPassword()));
   }
 
   default int getDatabase() {

--- a/src/main/java/redis/clients/jedis/JedisFactory.java
+++ b/src/main/java/redis/clients/jedis/JedisFactory.java
@@ -142,6 +142,11 @@ public class JedisFactory implements PooledObjectFactory<Jedis> {
     ((DefaultJedisSocketFactory) jedisSocketFactory).updateHostAndPort(hostAndPort);
   }
 
+  /**
+   * @deprecated Use {@link RedisCredentialsProvider} through
+   * {@link JedisClientConfig#getCredentialsProvider()}.
+   */
+  @Deprecated
   public void setPassword(final String password) {
     this.clientConfig.updatePassword(password);
   }

--- a/src/main/java/redis/clients/jedis/Protocol.java
+++ b/src/main/java/redis/clients/jedis/Protocol.java
@@ -49,7 +49,7 @@ public final class Protocol {
   private static final String NOPERM_PREFIX = "NOPERM";
 
   private Protocol() {
-    // this prevent the class from instantiation
+    throw new InstantiationError("Must not instantiate this class");
   }
 
   public static void sendCommand(final RedisOutputStream os, CommandArguments args) {

--- a/src/main/java/redis/clients/jedis/RedisCredentials.java
+++ b/src/main/java/redis/clients/jedis/RedisCredentials.java
@@ -1,0 +1,15 @@
+package redis.clients.jedis;
+
+public interface RedisCredentials {
+
+  /**
+   * @return Redis ACL user
+   */
+  default String getUser() {
+    return null;
+  }
+
+  default char[] getPassword() {
+    return null;
+  }
+}

--- a/src/main/java/redis/clients/jedis/RedisCredentialsProvider.java
+++ b/src/main/java/redis/clients/jedis/RedisCredentialsProvider.java
@@ -1,0 +1,27 @@
+package redis.clients.jedis;
+
+import java.util.function.Supplier;
+
+public interface RedisCredentialsProvider extends Supplier<RedisCredentials> {
+
+  /**
+   * Prepare {@link RedisCredentials} before {@link RedisCredentialsProvider#get()} is called.
+   * <p>
+   * An application may:
+   * <ul>
+   * <li>Load credentials from the credentials management system</li>
+   * <li>Reload credentials when credentials are rotated.</li>
+   * <li>Reload credentials after an authentication error (e.g. NOAUTH, WRONGPASS, etc).</li>
+   * <li>Minimize the time that the password lives in the memory (in combination with
+   * {@link RedisCredentialsProvider#cleanUp()}).</li>
+   * </ul>
+   */
+  default void prepare() { }
+
+  /**
+   * Clean up credentials (e.g. from memory).
+   *
+   * @see RedisCredentialsProvider#prepare()
+   */
+  default void cleanUp() { }
+}

--- a/src/test/java/redis/clients/jedis/JedisPooledTest.java
+++ b/src/test/java/redis/clients/jedis/JedisPooledTest.java
@@ -6,6 +6,7 @@ import static org.junit.Assert.fail;
 
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
 import org.junit.Test;
 
@@ -168,6 +169,84 @@ public class JedisPooledTest {
       factory.setPassword("foobared");
       pool.set("foo", "bar");
       assertEquals("bar", pool.get("foo"));
+    }
+  }
+
+  @Test
+  public void testResetValidCredentials() {
+    DefaultRedisCredentialsProvider credentialsProvider = 
+        new DefaultRedisCredentialsProvider(new DefaultRedisCredentials(null, "bad password"));
+
+    try (JedisPooled pool = new JedisPooled(HostAndPorts.getRedisServers().get(0),
+        DefaultJedisClientConfig.builder().credentialsProvider(credentialsProvider)
+            .clientName("my_shiny_client_name").build())) {
+      try {
+        pool.get("foo");
+        fail("Should not get resource from pool");
+      } catch (JedisException e) { }
+      assertEquals(0, pool.getPool().getNumActive());
+
+      credentialsProvider.setCredentials(new DefaultRedisCredentials(null, "foobared"));
+      pool.set("foo", "bar");
+      assertEquals("bar", pool.get("foo"));
+    }
+  }
+
+  @Test
+  public void testCredentialsProvider() {
+    final AtomicInteger prepareCount = new AtomicInteger();
+    final AtomicInteger cleanupCount = new AtomicInteger();
+
+    RedisCredentialsProvider credentialsProvider = new RedisCredentialsProvider() {
+      boolean firstCall = true;
+
+      @Override
+      public void prepare() {
+        prepareCount.incrementAndGet();
+      }
+
+      @Override
+      public RedisCredentials get() {
+        if (firstCall) {
+          firstCall = false;
+          return new RedisCredentials() { };
+        }
+
+        return new RedisCredentials() {
+          @Override
+          public String getUser() {
+            return null;
+          }
+
+          @Override
+          public char[] getPassword() {
+            return "foobared".toCharArray();
+          }
+        };
+      }
+
+      @Override
+      public void cleanUp() {
+        cleanupCount.incrementAndGet();
+      }
+    };
+
+    try (JedisPooled pool = new JedisPooled(HostAndPorts.getRedisServers().get(0),
+        DefaultJedisClientConfig.builder().credentialsProvider(credentialsProvider)
+            .clientName("my_shiny_client_name").build())) {
+      try {
+        pool.get("foo");
+        fail("Should not get resource from pool");
+      } catch (JedisException e) {
+      }
+      assertEquals(0, pool.getPool().getNumActive());
+      assertEquals(1, prepareCount.get());
+      assertEquals(1, cleanupCount.get());
+
+      pool.set("foo", "bar");
+      assertEquals("bar", pool.get("foo"));
+      assertEquals(2, prepareCount.get());
+      assertEquals(2, cleanupCount.get());
     }
   }
 }

--- a/src/test/java/redis/clients/jedis/examples/RedisCredentialsProviderExample.java
+++ b/src/test/java/redis/clients/jedis/examples/RedisCredentialsProviderExample.java
@@ -1,0 +1,44 @@
+package redis.clients.jedis.examples;
+
+import redis.clients.jedis.DefaultJedisClientConfig;
+import redis.clients.jedis.DefaultRedisCredentials;
+import redis.clients.jedis.DefaultRedisCredentialsProvider;
+import redis.clients.jedis.HostAndPort;
+import redis.clients.jedis.JedisPooled;
+
+public class RedisCredentialsProviderExample {
+
+  public static void main(String[] args) {
+
+    DefaultRedisCredentials initialCredentials
+        = new DefaultRedisCredentials("<INITIAL_USERNAME>", "<INITIAL_PASSWORD>");
+
+    DefaultRedisCredentialsProvider credentialsProvider
+        = new DefaultRedisCredentialsProvider(initialCredentials);
+
+    final String host = "<HOST>";
+    final int port = 6379;
+    final HostAndPort address = new HostAndPort(host, port);
+    final DefaultJedisClientConfig clientConfig
+        = DefaultJedisClientConfig.builder()
+            .credentialsProvider(credentialsProvider).build();
+
+    JedisPooled jedis = new JedisPooled(address, clientConfig);
+
+    // ...
+    // do operations with jedis
+    // ...
+
+    // when credentials is required to be updated
+    DefaultRedisCredentials updatedCredentials
+        = new DefaultRedisCredentials("<UPDATED_USERNAME>", "<UPDATED_PASSWORD>");
+
+    credentialsProvider.setCredentials(updatedCredentials);
+
+    // ...
+    // continue doing operations with jedis
+    // ...
+
+    jedis.close();
+  }
+}


### PR DESCRIPTION
References:

1. https://github.com/redis/jedis/issues/1602 and related PRs. Current PR is probably better than handling in JedisFactory 
2. https://github.com/redis/redis-py/pull/2261 - main reason of this PR 
3. https://github.com/lettuce-io/lettuce-core/issues/1774 
4. https://github.com/redis/jedis/issues/632 

---

* Introduce credentials provider

* use volatile

* Test in Sentineled mode

* Support CharSequence in DefaultRedisCredentials

* Added doc for prepare() and cleanUp()

* Test the provider interface

* Added example

* Removed deprecations